### PR TITLE
fix(ci): add python-version to setup-uv for consistent cache keys

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -12,10 +12,16 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up uv
+        id: setup-uv
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
           python-version: "3.11"
+
+      - name: Cache status
+        run: |
+          echo "cache-hit=${{ steps.setup-uv.outputs.cache-hit }}"
+          echo "cache-key=${{ steps.setup-uv.outputs.cache-key }}"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,5 @@
 name: Tests
 # Cache fix: python-version ensures setup-uv cache key matches project Python
-
 on:
   pull_request:
     types: [opened, synchronize, reopened]

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,4 +1,5 @@
 name: Tests
+# Cache fix: python-version ensures setup-uv cache key matches project Python
 
 on:
   pull_request:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -15,6 +15,7 @@ jobs:
         uses: astral-sh/setup-uv@v5
         with:
           enable-cache: true
+          python-version: "3.11"
 
       - name: Set up Python
         run: uv python install 3.11

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,5 +1,5 @@
 name: Tests
-# Cache fix: python-version ensures setup-uv cache key matches project Python
+
 on:
   pull_request:
     types: [opened, synchronize, reopened]
@@ -12,16 +12,7 @@ jobs:
       - uses: actions/checkout@v4
 
       - name: Set up uv
-        id: setup-uv
         uses: astral-sh/setup-uv@v5
-        with:
-          enable-cache: true
-          python-version: "3.11"
-
-      - name: Cache status
-        run: |
-          echo "cache-hit=${{ steps.setup-uv.outputs.cache-hit }}"
-          echo "cache-key=${{ steps.setup-uv.outputs.cache-key }}"
 
       - name: Set up Python
         run: uv python install 3.11


### PR DESCRIPTION
Fixes cache key mismatch in setup-uv. The workflow uses Python 3.11 but setup-uv was detecting system Python (3.12.3), causing inconsistent cache keys. Adding `python-version: "3.11"` ensures the cache key matches the project's Python version.