### PR TITLE
feat: add --tier flag for multi-tier extraction pipeline

### DIFF
--- a/cli/ds_enrich.py
+++ b/cli/ds_enrich.py
@@ -1,0 +1,86 @@
+"""Tier 3 enrichment: send needs_external figures to a flagship model.
+
+This is a standalone CLI that reads existing extraction output and lists
+(or in the future, processes) figures that local models could not resolve.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import logging
+import sys
+from pathlib import Path
+
+logger = logging.getLogger(__name__)
+
+
+def build_parser() -> argparse.ArgumentParser:
+    parser = argparse.ArgumentParser(
+        description="Enrich datasheet figures that need external LLM processing",
+    )
+    parser.add_argument(
+        "--out",
+        type=Path,
+        default=Path("./out"),
+        help="Output directory from a prior datasheet-extract run (default: ./out)",
+    )
+    return parser
+
+
+def main() -> int:
+    parser = build_parser()
+    args = parser.parse_args()
+    logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    out_dir: Path = args.out
+    if not out_dir.is_dir():
+        print(f"Error: output directory not found: {out_dir}", file=sys.stderr)
+        return 1
+
+    # Collect all rollup files (per-PDF and global)
+    rollup_paths = sorted(out_dir.glob("*/processing_rollup.json"))
+    global_rollup = out_dir / "processing_rollup.json"
+    if global_rollup.exists():
+        rollup_paths.append(global_rollup)
+
+    if not rollup_paths:
+        print(f"Error: no processing_rollup.json found under {out_dir}", file=sys.stderr)
+        return 1
+
+    total_needs = 0
+    for rollup_path in rollup_paths:
+        rollup = json.loads(rollup_path.read_text(encoding="utf-8"))
+        needs = rollup.get("figures", {}).get("needs_external", [])
+        if not needs:
+            continue
+
+        label = rollup_path.parent.name
+        logger.info("%s: %d figure(s) need external processing:", label, len(needs))
+        for fig in needs:
+            logger.info(
+                "  %s → %s [%s]",
+                fig["id"],
+                fig.get("image_path", ""),
+                fig.get("classification", ""),
+            )
+        total_needs += len(needs)
+
+    if total_needs == 0:
+        logger.info("All figures are already resolved — nothing to enrich.")
+    else:
+        logger.info(
+            "Total: %d figure(s) across %d PDF(s) need external processing.",
+            total_needs,
+            len([p for p in rollup_paths
+                 if json.loads(p.read_text(encoding="utf-8"))
+                 .get("figures", {}).get("needs_external")]),
+        )
+        logger.info("Hint: use prompts/figure_analysis.md as the prompt template.")
+        logger.info("Future: this command will call Claude API / OpenAI API to resolve them.")
+
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/cli/ds_extract.py
+++ b/cli/ds_extract.py
@@ -1,12 +1,22 @@
 from __future__ import annotations
 
 import argparse
+import json
 import logging
 import sys
 from pathlib import Path
 
 from src.extract_docling import DEFAULT_MAX_TOKENS
+from src.local_processor import detect_ollama_model_for_tier
 from src.pipeline import run_pipeline
+
+logger = logging.getLogger(__name__)
+
+# Default Ollama models per tier
+_TIER_DEFAULTS: dict[int, str] = {
+    1: "moondream:latest",
+    2: "qwen2.5vl:7b",
+}
 
 
 def build_parser() -> argparse.ArgumentParser:
@@ -29,12 +39,23 @@ def build_parser() -> argparse.ArgumentParser:
         help="Maximum number of figures to process (default: no limit)",
     )
     parser.add_argument(
+        "--tier",
+        type=int,
+        choices=[1, 2, 3],
+        default=1,
+        help=(
+            "Extraction tier: "
+            "1=fast local (moondream, no chart extraction), "
+            "2=enriched local (qwen + Docling chart extraction + VLM descriptions), "
+            "3=enrich existing output with external model (default: 1)"
+        ),
+    )
+    parser.add_argument(
         "--ollama-model",
         default=None,
         help=(
-            "Ollama vision model used both for Docling's embedded VLM enrichment "
-            "and post-extraction figure classification. "
-            "Recommended: qwen2.5vl:7b (auto-detected if omitted)."
+            "Override the Ollama vision model for figure processing. "
+            "Default depends on tier: moondream:latest (tier 1), qwen2.5vl:7b (tier 2)."
         ),
     )
     parser.add_argument("--max-tokens", type=int, default=DEFAULT_MAX_TOKENS,
@@ -42,10 +63,62 @@ def build_parser() -> argparse.ArgumentParser:
     return parser
 
 
+def _run_enrich(out_dir: Path) -> int:
+    """Tier 3: read existing rollup and list figures that need external processing."""
+    rollup_paths = sorted(out_dir.glob("*/processing_rollup.json"))
+    if not rollup_paths:
+        global_rollup = out_dir / "processing_rollup.json"
+        if global_rollup.exists():
+            rollup_paths = [global_rollup]
+
+    if not rollup_paths:
+        print(f"Error: no processing_rollup.json found under {out_dir}", file=sys.stderr)
+        return 1
+
+    total_needs = 0
+    for rollup_path in rollup_paths:
+        rollup = json.loads(rollup_path.read_text(encoding="utf-8"))
+        needs = rollup.get("figures", {}).get("needs_external", [])
+        if needs:
+            logger.info("%s: %d figure(s) need external processing", rollup_path.parent.name, len(needs))
+            for fig in needs:
+                logger.info("  %s → %s [%s]", fig["id"], fig.get("image_path", ""), fig.get("classification", ""))
+            total_needs += len(needs)
+
+    if total_needs == 0:
+        logger.info("All figures are already resolved — nothing to enrich.")
+    else:
+        logger.info(
+            "Total: %d figure(s) across %d PDF(s) need external processing.",
+            total_needs,
+            len(rollup_paths),
+        )
+        logger.info("Hint: use prompts/figure_analysis.md as the prompt template.")
+
+    return 0
+
+
 def main() -> int:
     parser = build_parser()
     args = parser.parse_args()
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
+
+    # Tier 3: enrichment pass on existing output
+    if args.tier == 3:
+        return _run_enrich(args.out)
+
+    # Resolve ollama model: explicit override > auto-detect for tier > tier default
+    ollama_model = args.ollama_model
+    if ollama_model is None:
+        detected = detect_ollama_model_for_tier(args.tier)
+        if detected:
+            ollama_model = detected
+            logger.info("Auto-detected Ollama model for tier %d: %s", args.tier, ollama_model)
+        else:
+            ollama_model = _TIER_DEFAULTS.get(args.tier)
+            logger.info("Using default Ollama model for tier %d: %s", args.tier, ollama_model)
+
+    do_chart_extraction = args.tier >= 2
 
     if args.file:
         pdf = args.file.resolve()
@@ -70,8 +143,9 @@ def main() -> int:
         no_images=args.no_images,
         no_tables=args.no_tables,
         max_figures=args.max_figures,
-        ollama_model=args.ollama_model,
+        ollama_model=ollama_model,
         max_tokens=args.max_tokens,
+        do_chart_extraction=do_chart_extraction,
     )
     return 0
 

--- a/cli/smoke_test.py
+++ b/cli/smoke_test.py
@@ -16,7 +16,7 @@ def main() -> int:
 
     logging.basicConfig(level=logging.INFO, format="%(levelname)s %(name)s: %(message)s")
 
-    run_pipeline(input_dir=args.input, out_dir=args.out, force=True)
+    run_pipeline(input_dir=args.input, out_dir=args.out, force=True, do_chart_extraction=False)
 
     pdfs = sorted(args.input.glob("*.pdf"))
     if not pdfs:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -18,6 +18,7 @@ dependencies = [
 
 [project.scripts]
 datasheet-extract = "cli.ds_extract:main"
+datasheet-enrich = "cli.ds_enrich:main"
 datasheet-smoke-test = "cli.smoke_test:main"
 
 [dependency-groups]

--- a/src/extract_docling.py
+++ b/src/extract_docling.py
@@ -48,6 +48,7 @@ def _extract_with_docling(
     out_dir: Path | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
     vlm_model: str | None = None,
+    do_chart_extraction: bool = False,
 ) -> dict[str, Any]:
     """Extract text, tables, and figures from a PDF using Docling.
 
@@ -71,15 +72,11 @@ def _extract_with_docling(
     from docling_core.types.doc import PictureItem, TableItem
     from transformers import AutoTokenizer
 
-    # Configure pipeline to generate images and run chart extraction.
-    # do_chart_extraction also auto-enables picture classification so every
-    # PictureItem gets a class label (bar_chart, line_chart, etc.) in addition
-    # to structured tabular data when the chart can be parsed.
     pipeline_options = PdfPipelineOptions()
     pipeline_options.images_scale = IMAGE_RESOLUTION_SCALE
     pipeline_options.generate_page_images = False
     pipeline_options.generate_picture_images = True
-    pipeline_options.do_chart_extraction = True
+    pipeline_options.do_chart_extraction = do_chart_extraction
 
     if vlm_model:
         # Embed VLM descriptions during Docling conversion via Ollama's
@@ -289,6 +286,7 @@ def extract_document(
     out_dir: Path | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
     vlm_model: str | None = None,
+    do_chart_extraction: bool = False,
 ) -> dict[str, Any]:
     """Extract document content using Docling.
 
@@ -297,9 +295,17 @@ def extract_document(
     each picture.  The description is embedded in the returned figure dicts
     under the key ``vlm_description`` and can be used downstream to skip a
     redundant second Ollama call.
+
+    When *do_chart_extraction* is True, Docling loads the IBM Granite VLM
+    (~6 GB) in-process to parse chart data and classify pictures.  This is
+    very slow and memory-hungry; leave disabled when using an Ollama VLM.
     """
     return _extract_with_docling(
-        pdf_path, out_dir=out_dir, max_tokens=max_tokens, vlm_model=vlm_model
+        pdf_path,
+        out_dir=out_dir,
+        max_tokens=max_tokens,
+        vlm_model=vlm_model,
+        do_chart_extraction=do_chart_extraction,
     )
 
 

--- a/src/local_processor.py
+++ b/src/local_processor.py
@@ -196,6 +196,51 @@ def _detect_ollama_model() -> str | None:
     return None
 
 
+def detect_ollama_model_for_tier(tier: int) -> str | None:
+    """Pick the best available Ollama vision model for the given tier.
+
+    Tier 1 prefers lightweight models (moondream) for speed.
+    Tier 2 prefers capable models (qwen2.5vl) for richer descriptions.
+    """
+    import ollama
+
+    try:
+        result = ollama.list()
+    except Exception as exc:
+        logger.debug("Could not list ollama models: %s", exc)
+        return None
+
+    if hasattr(result, "models"):
+        model_list = result.models
+    elif isinstance(result, dict):
+        model_list = result.get("models", [])
+    else:
+        model_list = []
+
+    model_names = []
+    for m in model_list:
+        if hasattr(m, "model"):
+            name = m.model
+        elif isinstance(m, dict):
+            name = m.get("name", "") or m.get("model", "")
+        else:
+            name = str(m)
+        model_names.append(name.lower())
+
+    if tier == 1:
+        # Tier 1: prefer small/fast models first
+        preference = ["moondream", "qwen2.5vl", "qwen2.5-vl", "qwen2-vl", "qwen2vl"]
+    else:
+        # Tier 2+: prefer capable models first
+        preference = ["qwen2.5vl", "qwen2.5-vl", "qwen2-vl", "qwen2vl", "moondream"]
+
+    for candidate in preference:
+        for name in model_names:
+            if candidate in name:
+                return name
+    return None
+
+
 def _infer_classification(description: str) -> str:
     """Infer a classification from a free-text description using keywords."""
     text = description.lower()

--- a/src/pipeline.py
+++ b/src/pipeline.py
@@ -94,6 +94,7 @@ def process_pdf(
     max_figures: int | None = None,
     ollama_model: str | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
+    do_chart_extraction: bool = False,
 ) -> dict:
     """Process a single PDF and persist all per-document artifacts."""
     pdf_out = ensure_dir(out_root / pdf_path.stem)
@@ -106,12 +107,14 @@ def process_pdf(
             shutil.rmtree(stale)
 
     # Pass ``out_dir`` so Docling can write figure images directly to disk.
-    # Pass ``vlm_model`` so Docling embeds VLM descriptions during conversion.
+    # Tier 1 (do_chart_extraction=False): no Docling VLM, fast layout+OCR only.
+    # Tier 2 (do_chart_extraction=True): enable Docling VLM descriptions via ollama.
     raw = extract_document(
         pdf_path,
         out_dir=pdf_out if not no_images else None,
         max_tokens=max_tokens,
-        vlm_model=ollama_model,
+        vlm_model=ollama_model if do_chart_extraction else None,
+        do_chart_extraction=do_chart_extraction,
     )
     blocks = to_blocks(raw.get("blocks", []))
     page_filter = parse_page_ranges(pages)
@@ -384,6 +387,7 @@ def run_pipeline(
     max_figures: int | None = None,
     ollama_model: str | None = None,
     max_tokens: int = DEFAULT_MAX_TOKENS,
+    do_chart_extraction: bool = False,
 ) -> dict:
     """Run the extraction pipeline for all matching PDFs in ``input_dir``."""
     ensure_dir(out_dir)
@@ -402,6 +406,7 @@ def run_pipeline(
             max_figures=max_figures,
             ollama_model=ollama_model,
             max_tokens=max_tokens,
+            do_chart_extraction=do_chart_extraction,
         )
         for pdf in pdfs
     ]

--- a/tests/test_chart_extraction.py
+++ b/tests/test_chart_extraction.py
@@ -47,7 +47,7 @@ startxref
 def _fake_extract(figures_dir: Path, chart_data: list[list[str]] | None, docling_cls: str):
     """Return a fake extract_document function for the given figure config."""
 
-    def fake_extract_document(_pdf_path, out_dir=None, max_tokens=256, vlm_model=None):
+    def fake_extract_document(_pdf_path, out_dir=None, max_tokens=256, vlm_model=None, do_chart_extraction=False):
         fdir = out_dir / "figures"
         fdir.mkdir(parents=True, exist_ok=True)
         Image.new("RGB", (60, 60), color="white").save(fdir / "fig_0001.png")

--- a/tests/test_pipeline_consistency.py
+++ b/tests/test_pipeline_consistency.py
@@ -50,7 +50,7 @@ def test_local_llm_classification_is_canonical(monkeypatch, tmp_path: Path) -> N
     out_root = tmp_path / "out"
 
     # Pretend extraction produced one figure with a non-"other" rule label.
-    def fake_extract_document(_pdf_path, out_dir=None, max_tokens=256, vlm_model=None):
+    def fake_extract_document(_pdf_path, out_dir=None, max_tokens=256, vlm_model=None, do_chart_extraction=False):
         assert out_dir is not None
         figures_dir = out_dir / "figures"
         figures_dir.mkdir(parents=True, exist_ok=True)


### PR DESCRIPTION
## Summary

- Add `--tier {1,2,3}` CLI flag to control VLM processing depth: tier 1 (fast/moondream, no chart extraction), tier 2 (enriched/qwen + Docling chart extraction + VLM descriptions), tier 3 (enrich existing output with external model)
- Thread `do_chart_extraction` through `pipeline.py` and `extract_docling.py` so tier 1 skips Docling VLM entirely for fast layout+OCR-only runs
- Add `detect_ollama_model_for_tier()` in `local_processor.py` to auto-detect the best available model per tier (moondream-first for tier 1, qwen-first for tier 2)
- Create `datasheet-enrich` CLI stub (`cli/ds_enrich.py`) for tier 3 that reads `processing_rollup.json` and lists `needs_external` figures
- Update smoke test to explicitly use tier 1 defaults (`do_chart_extraction=False`)
- Update test mocks for new `do_chart_extraction` parameter signature

## Test plan

- [x] All 22 existing tests pass (`uv run pytest tests/ -v`)
- [ ] Run `datasheet-extract --tier 1 --file <pdf>` end-to-end and verify fast extraction with moondream
- [ ] Run `datasheet-extract --tier 2 --file <pdf>` and verify chart extraction + VLM descriptions
- [ ] Run `datasheet-extract --tier 3 --out ./out` and verify it lists needs_external figures
- [ ] Run `datasheet-enrich --out ./out` and verify same tier 3 stub output

🤖 Generated with [Claude Code](https://claude.com/claude-code)